### PR TITLE
fix a typo caught by lintian

### DIFF
--- a/INFO/Table.html
+++ b/INFO/Table.html
@@ -1085,7 +1085,7 @@
 <dt id="by-Daemmon-Hughes">by Daemmon Hughes</dt>
 <dd>
 
-<p>Much of the original development work on this module was sponsered by Stone Environmental Inc. (www.stone-env.com).</p>
+<p>Much of the original development work on this module was sponsored by Stone Environmental Inc. (www.stone-env.com).</p>
 
 <p>The text_block() method is a slightly modified copy of the one from Rick Measham&#39;s PDF::API2 tutorial at http://pdfapi2.sourceforge.net/cgi-bin/view/Main/YourFirstDocument</p>
 

--- a/lib/PDF/Table/Table.pod
+++ b/lib/PDF/Table/Table.pod
@@ -1183,7 +1183,7 @@ Note that Perl 5.10 is the minimum supported level.
 
 =item by Daemmon Hughes
 
-Much of the original development work on this module was sponsered by
+Much of the original development work on this module was sponsored by
 Stone Environmental Inc. (www.stone-env.com).
 
 The text_block() method is a slightly modified copy of the one from


### PR DESCRIPTION
While pulling the last release of PDF-Table into Debian, the linter
"lintian" caught a typo.  I thought you might be interested in the
resulting patch.

Signed-off-by: Étienne Mollier <emollier@debian.org>